### PR TITLE
- Fixed bug in fn_basicEquipment.sqf

### DIFF
--- a/AETEventMissionBase/Functions/Players/fn_basicEquipment.sqf
+++ b/AETEventMissionBase/Functions/Players/fn_basicEquipment.sqf
@@ -96,7 +96,7 @@ if (_GPSsForEveryone select 1) then {
 };
 
 if (getClientState == "BRIEFING READ") then {
-	if (__medicalAndMiscForEveryone) then {
+	if (_medicalAndMiscForEveryone) then {
 		if ((uniform player) != "") then {
 			private _playerUniform = uniformContainer player;
 			[_playerUniform, _uniformItems] spawn {


### PR DESCRIPTION
- Check for `_medicalAndMiscForEveryone` had an extra `_` before it.