### PR TITLE
no more hint for binocs being on safety

### DIFF
--- a/AETEventMissionBase/AET_scripts/AET_initPlayerLocal.sqf
+++ b/AETEventMissionBase/AET_scripts/AET_initPlayerLocal.sqf
@@ -6,13 +6,13 @@ if (hasInterface) then {
 // Gun safety script
 {
 	[ACE_player, _x, true] call ace_safemode_fnc_setWeaponSafety;
-} forEach (weapons ACE_player);
+} forEachReversed (weapons ACE_player);
 
 [missionNamespace, "AET_disclaimerDone", {
 	sleep 5;
 	{
 		[ACE_player, _x, false] call ace_safemode_fnc_setWeaponSafety;
-	} forEach (weapons ACE_player);
+	} forEachReversed (weapons ACE_player);
 }
 ] call BIS_fnc_addScriptedEventHandler;
 


### PR DESCRIPTION
iterates through all weapons in reverse, therefore it wont show the binocs as the last item being put on/off safety, but the primary rifle.